### PR TITLE
updated argument to xgb.model.dt.tree

### DIFF
--- a/R/buildExplainer.R
+++ b/R/buildExplainer.R
@@ -56,8 +56,14 @@
 buildExplainer = function(xgb.model, trainingData, type = "binary", base_score = 0.5){
 
   col_names = attr(trainingData, ".Dimnames")[[2]]
+  
+  best_ntreelimit <- xgb.model$best_ntreelimit
+  if(!is.null(xgb.model$best_ntreelimit)){
+    best_ntreelimit <- xgb.model$best_ntreelimit - 1
+  }
+
   cat('\nCreating the trees of the xgboost model...')
-  trees = xgb.model.dt.tree(col_names, model = xgb.model, n_first_tree = xgb.model$best_ntreelimit - 1)
+  trees = xgb.model.dt.tree(col_names, model = xgb.model, trees = best_ntreelimit)
   cat('\nGetting the leaf nodes for the training set observations...')
   nodes.train = predict(xgb.model,trainingData,predleaf =TRUE)
 


### PR DESCRIPTION
This pull request is meant to fix two bugs in the `buildExplainer` function. 
1. When when `xgb.model$best_ntreelimit` is `NULL`, subtracting one changes the value to an empty numeric vector when the value should still be `NULL`.
2. The `n_first_tree` argument to `xgb.model.dt.tree` has been deprecated and is now `trees`. `xgboost` has a deprecation check function that is supposed to handle the deprecated function gracefully but it wasn't working. 

I tested this update on the examples given for the `xgboost` function. [Here's a gist of that test](https://gist.github.com/nateaff/7e147a0c360f12f7586890fc6f356dd6). I was just tested for errors, not for correctness.     