### PR TITLE
defines the object i before it is used

### DIFF
--- a/R/showWaterfall.R
+++ b/R/showWaterfall.R
@@ -64,9 +64,11 @@ showWaterfall = function(xgb.model, explainer, DMatrix, data.matrix, idx, type =
 
 
   breakdown_summary = as.matrix(breakdown)[1,]
-  data_for_label = data.matrix[i,]
 
   i = order(abs(breakdown_summary),decreasing=TRUE)
+
+  data_for_label = data.matrix[i,]
+
   breakdown_summary = breakdown_summary[i]
   data_for_label = data_for_label[i]
 

--- a/R/showWaterfall.R
+++ b/R/showWaterfall.R
@@ -64,10 +64,12 @@ showWaterfall = function(xgb.model, explainer, DMatrix, data.matrix, idx, type =
 
 
   breakdown_summary = as.matrix(breakdown)[1,]
+  
+  data_for_label = data.matrix[idx,]
 
   i = order(abs(breakdown_summary),decreasing=TRUE)
 
-  data_for_label = data.matrix[i,]
+  
 
   breakdown_summary = breakdown_summary[i]
   data_for_label = data_for_label[i]


### PR DESCRIPTION
hey -- thanks a lot for putting the xgboost explainer package together. I've been trying to use it and ran into a bug in the showWaterfall function. There was an object i that was being used before it was defined, causing R to get confused. I fixed it here and the change was pretty minor. 

Thanks! 