### PR TITLE
Waterfall ggplot

### DIFF
--- a/R/showWaterfall.R
+++ b/R/showWaterfall.R
@@ -66,12 +66,12 @@ showWaterfall = function(xgb.model, explainer, DMatrix, data.matrix, idx, type =
 
 
   breakdown_summary = as.matrix(breakdown)[1,]
-  
+
   data_for_label = data.matrix[idx,]
 
   i = order(abs(breakdown_summary),decreasing=TRUE)
 
-  
+
 
   breakdown_summary = breakdown_summary[i]
   data_for_label = data_for_label[i]
@@ -114,15 +114,20 @@ showWaterfall = function(xgb.model, explainer, DMatrix, data.matrix, idx, type =
   cat('\n')
   print(breakdown_summary)
 
+
   if (type == 'regression'){
 
   waterfalls::waterfall(values = breakdown_summary,
                         rect_text_labels = round(breakdown_summary, 2),
                         labels = labels,
                         total_rect_text = round(weight, 2),
-                        calc_total = TRUE,
-                        total_axis_text = "Prediction") +
-                          theme(axis.text.x = element_text(angle = 45, hjust = 1))
+                        calc_total = calcTotal,
+                        total_axis_text = "Prediction",
+                        print_plot = printPlot) +
+                          theme(axis.text.x = element_text(angle = 45,
+                                                           hjust = 1),
+                                axis.title = element_text(),
+                                axis.title.x = element_blank())
   }else{
 
     inverse_logit_trans <- scales::trans_new("inverse logit",
@@ -138,11 +143,14 @@ showWaterfall = function(xgb.model, explainer, DMatrix, data.matrix, idx, type =
                           rect_text_labels = round(breakdown_summary, 2),
                           labels = labels,
                           total_rect_text = round(weight, 2),
-                          calc_total = TRUE,
-                          total_axis_text = "Prediction")  +
+                          calc_total = calcTotal,
+                          total_axis_text = "Prediction",
+                          print_plot = printPlot)  +
                             scale_y_continuous(labels = inverse_logit_labels,
-                                                breaks = ybreaks) +
-                            theme(axis.text.x = element_text(angle = 45, hjust = 1))
-
+                                               breaks = ybreaks) +
+                            theme(axis.text.x = element_text(angle = 45,
+                                                             hjust = 1),
+                                  axis.title = element_text(),
+                                  axis.title.x = element_blank())
   }
 }

--- a/R/showWaterfall.R
+++ b/R/showWaterfall.R
@@ -8,6 +8,8 @@
 #' @param idx The row number of the data to be explained
 #' @param type The objective function of the model - either "binary" (for binary:logistic) or "regression" (for reg:linear)
 #' @param threshold Default = 0.0001. The waterfall chart will group all variables with absolute impact less than the threshold into a variable called 'Other'
+#' @param printPlot Default = TRUE, which prints the plot. If FALSE, returns ggplot object (e.g. for adding labels to)
+#' @param calcTotal Default = TRUE, which calculates and plots the total pool of the waterfall.
 #' @return None
 #' @export
 #' @import data.table
@@ -50,7 +52,7 @@
 #' showWaterfall(xgb.model, explainer, xgb.test.data, test.data,  2, type = "binary")
 #' showWaterfall(xgb.model, explainer, xgb.test.data, test.data,  8, type = "binary")
 
-showWaterfall = function(xgb.model, explainer, DMatrix, data.matrix, idx, type = "binary", threshold = 0.0001){
+showWaterfall = function(xgb.model, explainer, DMatrix, data.matrix, idx, type = "binary", threshold = 0.0001, printPlot = TRUE, calcTotal = TRUE){
 
 
   breakdown = explainPredictions(xgb.model, explainer, slice(DMatrix,as.integer(idx)))


### PR DESCRIPTION
This commit adds two parameters so that you can:
-  stop showWaterfall from calculating the total waterfall pool
-  disable printing so that the plot is returned as a ggplot object

It also tweaks the theme slightly so that you can label the y-axis post hoc using ggplot2::ylab